### PR TITLE
改行ルールを改良

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
     document: false,
     expect: false,
     it: false,
+    Node: false,
     waitsFor: false,
     waitsForPromise: false,
     runs: false,

--- a/lib/html-elmfier.js
+++ b/lib/html-elmfier.js
@@ -2,6 +2,7 @@
 
 import { CompositeDisposable } from 'atom';
 import path from 'path';
+import htmlParser from './html-parser';
 
 export default {
 
@@ -35,60 +36,50 @@ export default {
         || !/<(.*?)>/.test(event.text)) {
         return;
       }
-      const rootDiv = document.createElement('div');
-      rootDiv.innerHTML = event.text;
-      if (rootDiv.children.length === 0) {
-        return;
+      const nodes = htmlParser.parse(event.text);
+      const elmText = this.toElmText(nodes, 1);
+      if (elmText.length > 0) {
+        editor.setTextInBufferRange(event.range, elmText);
       }
-      const replacedText = this.replaceHtmlNodes(rootDiv.childNodes, 0);
-      const emptyRemovedText = replacedText.replace(/^\n {4}/, '')
-        .replace(/\[ {2}\]/g, '[]')
-        .replace(/ \n/g, '\n');
-      editor.setTextInBufferRange(event.range, emptyRemovedText);
     }));
   },
 
-  replaceHtmlNodes(nodes, indentLength) {
-    indentLength++;
-    const childrenTexts = Array.from(nodes).map((node) => {
-      if (!node.tagName) {
-        const nodeData = node.data
-          .replace(/\s+/g, ' ')
-          .replace(/(^\s)|(\s$)/g, '');
-        if (nodeData.length) {
-          return `text "${nodeData}"`;
-        }
-        return null;
+  toElmText(nodes, indentLength) {
+    return nodes.filter(node => !node.isComment).map((node) => {
+      if (node.isText) {
+        return `text "${node.textValue}"`;
       }
-      const indents = ' '.repeat(4 * indentLength);
-      const tag = node.tagName.toLowerCase();
-      const attr = this.makeAttrString(node.attributes);
-      let children = '';
-      if (node.childNodes.length) {
-        children = this.replaceHtmlNodes(node.childNodes, indentLength);
-      }
-      return `\n${indents}${tag} ${attr} [ ${children} ]`;
-    }).filter(elm => elm);
-    return childrenTexts.join(', ');
+      const attrListText = this.createAttrListText(node.attributes);
+      const childNodeListText = this.createChildNodeListText(
+        node.childNodes, indentLength,
+      );
+      return `${node.tagName} ${attrListText} ${childNodeListText}`;
+    }).join(`,\n${this.createIndent(indentLength)}`);
   },
 
-  makeAttrString(attributes) {
-    const attrStringUnits = Array.from(attributes).map((key) => {
-      const attrName = this.formatAttrName(key.nodeName);
-      const attrVal = this.formatAttrVal(key.nodeValue);
-      return `${attrName} ${attrVal}`;
+  createAttrListText(attrs) {
+    if (attrs.length === 0) return '[]';
+    const exprs = Array.from(attrs).map((attr) => {
+      const name = (attr.nodeName === 'type') ? 'type_' : attr.nodeName;
+      const value = /^[1-9][0-9]*$/.test(attr.nodeValue)
+        ? attr.nodeValue : `"${attr.nodeValue}"`;
+      return `${name} ${value}`;
     });
-    const attributesString = attrStringUnits.length === 0
-      ? '' : ` ${attrStringUnits.join(', ')} `;
-    return `[${attributesString}]`;
+    return `[ ${exprs.join(', ')} ]`;
   },
 
-  formatAttrName(attrName) {
-    return (attrName === 'type') ? `${attrName}_` : attrName;
+  createChildNodeListText(childNodes, indentLength) {
+    if (childNodes.length === 0) return '[]';
+    const childrenText = this.toElmText(childNodes, indentLength + 1);
+    if (childNodes.length === 1 && childNodes[0].isText) {
+      return `[ ${childrenText} ]`;
+    }
+    const indent = this.createIndent(indentLength + 1);
+    return `[\n${indent}${childrenText} ]`;
   },
 
-  formatAttrVal(attrVal) {
-    return /^[1-9](|([0-9]*?))$/.test(attrVal) ? attrVal : `"${attrVal}"`;
+  createIndent(len) {
+    return ' '.repeat(4 * len);
   },
 
   isElmEditor(editor) {

--- a/lib/html-parser.js
+++ b/lib/html-parser.js
@@ -1,0 +1,58 @@
+'use babel';
+
+/**
+ * @typedef {Object} SaneNode
+ * @property {NamedNodeMap} attributes
+ * @property {Array.<SaneNode>} childNodes
+ * @property {string} commentValue
+ * @property {boolean} isComment
+ * @property {boolean} isText
+ * @property {string} tagName
+ * @property {string} textValue
+ */
+
+/**
+ * JSのうんちみたいなNodeオブジェクトを再解釈する。
+ * ワイのまともなオブジェクトへと置き換えるんや。
+ * @param  {Iterable.<Node>} nodes
+ * @return {Array.<SaneNode>}
+ */
+const reinterpretNodes = (nodes) => {
+  const saneNodes = [];
+  nodes.forEach((node) => {
+    const saneNode = {};
+    saneNode.isText = node.nodeType === Node.TEXT_NODE;
+    saneNode.isComment = node.nodeType === Node.COMMENT_NODE;
+
+    if (saneNode.isComment) {
+      saneNode.commentValue = node.data
+        .replace(/^[ \t]+/mg, ''); // 行頭のインデントは要らんねん。
+    } else if (saneNode.isText) {
+      saneNode.textValue = node.data
+        .replace(/\s+/g, ' ') // HTMLでスペースや改行がいくらあっても意味ないねん。
+        .trim();
+      // スペースや改行だけで出来てたNodeって、それただのHTMLの空白や！
+      if (saneNode.textValue === '') return;
+    } else {
+      saneNode.attributes = node.attributes;
+      saneNode.tagName = node.tagName.toLowerCase();
+      saneNode.childNodes = reinterpretNodes(node.childNodes);
+    }
+
+    saneNodes.push(saneNode);
+  });
+  return saneNodes;
+};
+
+export default {
+  /**
+   * HTMLをNodeに変換するんや。ワイの特製Nodeオブジェクトやで〜。
+   * @param  {string} html
+   * @return {Array.<SaneNode>}
+   */
+  parse(html) {
+    const virtualDiv = document.createElement('div');
+    virtualDiv.innerHTML = html;
+    return reinterpretNodes(virtualDiv.childNodes);
+  },
+};

--- a/spec/fixtures/copyFrom.html
+++ b/spec/fixtures/copyFrom.html
@@ -10,6 +10,7 @@
 <body>
     <!-- Copy start -->
 ^^^^<div class="wrapper" id="wrapper">
+        This is the beginning.
         <nav class="gNav" id="gNav">
             <ul class="gNav__list">
                 <li><a href="aaa.html"><span>link</span></a></li>
@@ -21,6 +22,8 @@
                 <li><a href="aaa.html"><span>link</span></a></li>
             </ul>
         </nav>
+        When <b>you</b> gaze into the <b>abyss</b>,<br>
+        the <b>abyss</b> gazes into <b>you</b>.
         <table class="table_class">
             <tr>
                 <td colspan="3" rowspan="3">td</td>

--- a/spec/fixtures/expected.elm
+++ b/spec/fixtures/expected.elm
@@ -1,5 +1,6 @@
 view model =
-    div [ class "wrapper", id "wrapper" ] [ text "This is the beginning.",
+    div [ class "wrapper", id "wrapper" ] [
+        text "This is the beginning.",
         nav [ class "gNav", id "gNav" ] [
             ul [ class "gNav__list" ] [
                 li [] [
@@ -10,12 +11,18 @@ view model =
                         span [] [ text "link link link" ] ] ],
                 li [] [
                     a [ href "aaa.html" ] [
-                        span [] [ text "link" ] ] ] ] ], text "When",
-        b [] [ text "you" ], text "gaze into the",
-        b [] [ text "abyss" ], text ",",
-        br [] [], text "the",
-        b [] [ text "abyss" ], text "gazes into",
-        b [] [ text "you" ], text ".",
+                        span [] [ text "link" ] ] ] ] ],
+        text "When",
+        b [] [ text "you" ],
+        text "gaze into the",
+        b [] [ text "abyss" ],
+        text ",",
+        br [] [],
+        text "the",
+        b [] [ text "abyss" ],
+        text "gazes into",
+        b [] [ text "you" ],
+        text ".",
         table [ class "table_class" ] [
             tbody [] [
                 tr [] [

--- a/spec/fixtures/expected.elm
+++ b/spec/fixtures/expected.elm
@@ -1,5 +1,5 @@
 view model =
-    div [ class "wrapper", id "wrapper" ] [
+    div [ class "wrapper", id "wrapper" ] [ text "This is the beginning.",
         nav [ class "gNav", id "gNav" ] [
             ul [ class "gNav__list" ] [
                 li [] [
@@ -10,7 +10,12 @@ view model =
                         span [] [ text "link link link" ] ] ],
                 li [] [
                     a [ href "aaa.html" ] [
-                        span [] [ text "link" ] ] ] ] ],
+                        span [] [ text "link" ] ] ] ] ], text "When",
+        b [] [ text "you" ], text "gaze into the",
+        b [] [ text "abyss" ], text ",",
+        br [] [], text "the",
+        b [] [ text "abyss" ], text "gazes into",
+        b [] [ text "you" ], text ".",
         table [ class "table_class" ] [
             tbody [] [
                 tr [] [

--- a/spec/fixtures/expectedIfNoExec.elm
+++ b/spec/fixtures/expectedIfNoExec.elm
@@ -1,5 +1,6 @@
 view model =
     <div class="wrapper" id="wrapper">
+        This is the beginning.
         <nav class="gNav" id="gNav">
             <ul class="gNav__list">
                 <li><a href="aaa.html"><span>link</span></a></li>
@@ -11,6 +12,8 @@ view model =
                 <li><a href="aaa.html"><span>link</span></a></li>
             </ul>
         </nav>
+        When <b>you</b> gaze into the <b>abyss</b>,<br>
+        the <b>abyss</b> gazes into <b>you</b>.
         <table class="table_class">
             <tr>
                 <td colspan="3" rowspan="3">td</td>

--- a/test/test.elm
+++ b/test/test.elm
@@ -1,5 +1,6 @@
 view model =
-    div [ class "wrapper", id "wrapper" ] [ text "This is the beginning.",
+    div [ class "wrapper", id "wrapper" ] [
+        text "This is the beginning.",
         nav [ class "gNav", id "gNav" ] [
             ul [ class "gNav__list" ] [
                 li [] [
@@ -10,12 +11,18 @@ view model =
                         span [] [ text "link link link" ] ] ],
                 li [] [
                     a [ href "aaa.html" ] [
-                        span [] [ text "link" ] ] ] ] ], text "When",
-        b [] [ text "you" ], text "gaze into the",
-        b [] [ text "abyss" ], text ",",
-        br [] [], text "the",
-        b [] [ text "abyss" ], text "gazes into",
-        b [] [ text "you" ], text ".",
+                        span [] [ text "link" ] ] ] ] ],
+        text "When",
+        b [] [ text "you" ],
+        text "gaze into the",
+        b [] [ text "abyss" ],
+        text ",",
+        br [] [],
+        text "the",
+        b [] [ text "abyss" ],
+        text "gazes into",
+        b [] [ text "you" ],
+        text ".",
         table [ class "table_class" ] [
             tbody [] [
                 tr [] [

--- a/test/test.elm
+++ b/test/test.elm
@@ -1,5 +1,5 @@
 view model =
-    div [ class "wrapper", id "wrapper" ] [
+    div [ class "wrapper", id "wrapper" ] [ text "This is the beginning.",
         nav [ class "gNav", id "gNav" ] [
             ul [ class "gNav__list" ] [
                 li [] [
@@ -10,7 +10,12 @@ view model =
                         span [] [ text "link link link" ] ] ],
                 li [] [
                     a [ href "aaa.html" ] [
-                        span [] [ text "link" ] ] ] ] ],
+                        span [] [ text "link" ] ] ] ] ], text "When",
+        b [] [ text "you" ], text "gaze into the",
+        b [] [ text "abyss" ], text ",",
+        br [] [], text "the",
+        b [] [ text "abyss" ], text "gazes into",
+        b [] [ text "you" ], text ".",
         table [ class "table_class" ] [
             tbody [] [
                 tr [] [

--- a/test/test.html
+++ b/test/test.html
@@ -13,6 +13,7 @@
 
 <body>
     <div class="wrapper" id="wrapper">
+      This is the beginning.
         <nav class="gNav" id="gNav">
             <ul class="gNav__list">
                 <li><a href="aaa.html"><span>link</span></a></li>
@@ -24,6 +25,8 @@
                 <li><a href="aaa.html"><span>link</span></a></li>
             </ul>
         </nav>
+        When <b>you</b> gaze into the <b>abyss</b>,<br>
+        the <b>abyss</b> gazes into <b>you</b>.
         <table class="table_class">
             <tr>
                 <td colspan="3" rowspan="3">td</td>


### PR DESCRIPTION
* 改行ルールを改良しました。
```html
<div>
    ほげほげ
    <span>ふがふが</span>
    ほげふが
</div>
```
before
```elm
div [] [ text "ほげほげ",
    span [] [ text "ふがふが" ], text "ほげふが" ]
```
after
```elm
div [] [
    text "ほげほげ",
    span [] [ text "ふがふが" ],
    text "ほげふが" ]
```

*   これを実現しやすくするために、大きくリファクタしました。
    *   インデントを再帰呼出前に指定するようにしました。
        *   before: `div [] [` + 再帰呼出結果`\n    span [] []` + ` ]`
            after: `div [] [\n    ` + 再帰呼出結果`span [] []` + ` ]`
        *   再帰呼出した部分も単体で成り立つようになっているのがポイントです。
            「結果の定義をどう使って手段を定義するか」という思考法です。
        *   これにより、最後にreplaceする部分のロジックを一掃できました。
    *   再帰呼出する前にインデントするかどうかを決めなきゃいけないので、再帰呼出前にchildNodesが「1つしかない&&その1つはTextである」ことを調べないといけません。
        これを容易にするため、「一通りDOMノードの解析をする」->「Elmに変換する」という風に2周する作りにしました。（解析はHtmlParser.jsで行う。）
        *   これにより、「解析しながら変換する」ではなく「解析は解析、変換は変換」と役割分担でき、それぞれのロジックの見通しが良くなりました。

ごちゃごちゃ説明したらかえって分かりづらくなってしまいました。
コードを先に読んだ方が分かりやすいかもしれません。